### PR TITLE
fix: send ydoc delta

### DIFF
--- a/packages/reflect-yjs/src/mutators.ts
+++ b/packages/reflect-yjs/src/mutators.ts
@@ -38,13 +38,27 @@ export async function updateYJS(
   tx: WriteTransaction,
   {name, update}: {name: string; update: string},
 ) {
-  const existing = await tx.get<string>(yjsProviderKey(name));
+  const existing = await tx.get<string>(yjsProviderUpdateKey(name));
   if (!existing) {
-    await tx.set(yjsProviderKey(name), update);
+    await tx.set(yjsProviderUpdateKey(name), update);
+    if (tx.location === 'server') {
+      await tx.set(
+        yjsProviderVectorKey(name),
+        base64.fromByteArray(
+          Y.encodeStateVectorFromUpdateV2(base64.toByteArray(update)),
+        ),
+      );
+    }
   } else {
     const updates = [base64.toByteArray(existing), base64.toByteArray(update)];
     const merged = Y.mergeUpdatesV2(updates);
-    await tx.set(yjsProviderKey(name), base64.fromByteArray(merged));
+    await tx.set(yjsProviderUpdateKey(name), base64.fromByteArray(merged));
+    if (tx.location === 'server') {
+      await tx.set(
+        yjsProviderVectorKey(name),
+        base64.fromByteArray(Y.encodeStateVectorFromUpdateV2(merged)),
+      );
+    }
   }
 }
 
@@ -52,8 +66,12 @@ function yjsAwarenessPrefix(name: string) {
   return `yjs/awareness/${name}/`;
 }
 
-export function yjsProviderKey(name: string): string {
-  return `yjs/provider/${name}`;
+export function yjsProviderUpdateKey(name: string): string {
+  return `yjs/provider/update/${name}`;
+}
+
+export function yjsProviderVectorKey(name: string): string {
+  return `yjs/provider/vector/${name}`;
 }
 
 export function yjsAwarenessKey(

--- a/packages/reflect-yjs/src/provider.ts
+++ b/packages/reflect-yjs/src/provider.ts
@@ -44,10 +44,10 @@ export class Provider {
         const v = await tx.get(yjsProviderServerKey(this.name));
         return typeof v === 'string' ? v : null;
       },
-      docStateFromReflect => {
-        if (docStateFromReflect !== null) {
+      docStateFromServer => {
+        if (docStateFromServer !== null) {
           this.#vector = Y.encodeStateVectorFromUpdateV2(
-            base64.toByteArray(docStateFromReflect),
+            base64.toByteArray(docStateFromServer),
           );
         }
       },
@@ -62,7 +62,6 @@ export class Provider {
   }
 
   #handleUpdate = async () => {
-    // We could/should use the update passed into the on('update') but encoding the whole state is easier for now.
     const diffUpdate = this.#vector
       ? Y.encodeStateAsUpdateV2(this.#ydoc, this.#vector)
       : Y.encodeStateAsUpdateV2(this.#ydoc);

--- a/packages/reflect-yjs/src/provider.ts
+++ b/packages/reflect-yjs/src/provider.ts
@@ -3,14 +3,17 @@ import * as base64 from 'base64-js';
 import * as Y from 'yjs';
 import {Awareness} from './awareness.js';
 import type {Mutators} from './mutators.js';
-import {yjsProviderKey} from './mutators.js';
+import {yjsProviderUpdateKey, yjsProviderVectorKey} from './mutators.js';
 
 export class Provider {
   readonly #reflect: Reflect<Mutators>;
   readonly #ydoc: Y.Doc;
   #awareness: Awareness | null = null;
-  #cancelSubscribe: () => void;
+  #cancelUpdateSubscribe: () => void;
+  #cancelVectorSubscribe: () => void;
+
   readonly name: string;
+  #vector: Uint8Array | null = null;
 
   constructor(reflect: Reflect<Mutators>, name: string, ydoc: Y.Doc) {
     this.#reflect = reflect;
@@ -20,15 +23,27 @@ export class Provider {
     ydoc.on('update', this.#handleUpdate);
     ydoc.on('destroy', this.#handleDestroy);
 
-    this.#cancelSubscribe = reflect.subscribe(
+    this.#cancelUpdateSubscribe = reflect.subscribe(
       async tx => {
-        const v = await tx.get(yjsProviderKey(this.name));
+        const v = await tx.get(yjsProviderUpdateKey(this.name));
         return typeof v === 'string' ? v : null;
       },
       docStateFromReflect => {
         if (docStateFromReflect !== null) {
           const update = base64.toByteArray(docStateFromReflect);
           Y.applyUpdateV2(ydoc, update);
+        }
+      },
+    );
+
+    this.#cancelVectorSubscribe = reflect.subscribe(
+      async tx => {
+        const v = await tx.get(yjsProviderVectorKey(this.name));
+        return typeof v === 'string' ? v : null;
+      },
+      docStateFromReflect => {
+        if (docStateFromReflect !== null) {
+          this.#vector = base64.toByteArray(docStateFromReflect);
         }
       },
     );
@@ -43,10 +58,12 @@ export class Provider {
 
   #handleUpdate = async () => {
     // We could/should use the update passed into the on('update') but encoding the whole state is easier for now.
-    const update = Y.encodeStateAsUpdateV2(this.#ydoc);
+    const diffUpdate = this.#vector
+      ? Y.encodeStateAsUpdateV2(this.#ydoc, this.#vector)
+      : Y.encodeStateAsUpdateV2(this.#ydoc);
     await this.#reflect.mutate.updateYJS({
       name: this.name,
-      update: base64.fromByteArray(update),
+      update: base64.fromByteArray(diffUpdate),
     });
   };
 
@@ -55,7 +72,9 @@ export class Provider {
   };
 
   destroy(): void {
-    this.#cancelSubscribe();
+    this.#cancelUpdateSubscribe();
+    this.#cancelVectorSubscribe();
+    this.#vector = null;
     this.#ydoc.off('destroy', this.#handleDestroy);
     this.#ydoc.off('update', this.#handleUpdate);
     this.#awareness?.destroy();


### PR DESCRIPTION
The idea here is that `yjs/provider/server/` always holds the full state of the document last received from the server and we can compute deltas against that value for mutations. `yjs/provider/client/` is for local optimistic document state.