### PR TITLE
chore: Limit the exports

### DIFF
--- a/packages/reflect-yjs/src/index.ts
+++ b/packages/reflect-yjs/src/index.ts
@@ -1,3 +1,3 @@
-export * from './awareness.js';
-export * from './provider.js';
-export * from './mutators.js';
+export {Awareness} from './awareness.js';
+export {mutators, type Mutators} from './mutators.js';
+export {Provider} from './provider.js';


### PR DESCRIPTION
Be explicit in what we export so that we do not accidentally export internal details.