### PR TITLE
feat: large document support

### DIFF
--- a/packages/reflect-yjs/src/mutators.ts
+++ b/packages/reflect-yjs/src/mutators.ts
@@ -20,24 +20,92 @@ export async function updateYJS(
   tx: WriteTransaction,
   {name, update}: {name: string; update: string},
 ) {
-  const existing = await tx.get<string>(yjsProviderServerKey(name));
-  const getKeyToSet =
-    tx.location === 'client' ? yjsProviderClientKey : yjsProviderServerKey;
+  const existing = await getServerUpdate(name, tx);
+  const set = tx.location === 'client' ? setClientUpdate : setServerUpdate;
   if (!existing) {
-    await tx.set(getKeyToSet(name), update);
+    await set(name, update, tx);
   } else {
     const updates = [base64.toByteArray(existing), base64.toByteArray(update)];
     const merged = Y.mergeUpdatesV2(updates);
-    await tx.set(getKeyToSet(name), base64.fromByteArray(merged));
+    await set(name, base64.fromByteArray(merged), tx);
   }
 }
 
-export function yjsProviderClientKey(name: string): string {
+function yjsProviderClientUpdateKey(name: string): string {
   return `yjs/provider/client/${name}`;
 }
 
-export function yjsProviderServerKey(name: string): string {
-  return `yjs/provider/server/${name}`;
+function yjsProviderServerUpdatePrefix(name: string): string {
+  return `yjs/provider/server/${name}/`;
+}
+
+function setClientUpdate(name: string, update: string, tx: WriteTransaction) {
+  return tx.set(yjsProviderClientUpdateKey(name), update);
+}
+
+async function setServerUpdate(
+  name: string,
+  update: string,
+  tx: WriteTransaction,
+) {
+  const writes = [];
+  let i = 0;
+  for (; i * CHUNK_LENGTH < update.length; i++) {
+    const existing = await tx.get(yjsProviderServerKey(name, i));
+    const chunk = update.substring(
+      i * CHUNK_LENGTH,
+      i * CHUNK_LENGTH + CHUNK_LENGTH,
+    );
+    if (existing !== chunk) {
+      writes.push(
+        tx.set(
+          yjsProviderServerKey(name, i),
+          update.substring(i * CHUNK_LENGTH, i * CHUNK_LENGTH + CHUNK_LENGTH),
+        ),
+      );
+    }
+  }
+  for await (const key of tx
+    .scan({
+      prefix: yjsProviderServerUpdatePrefix(name),
+      start: {
+        key: yjsProviderServerKey(name, i),
+        exclusive: false,
+      },
+    })
+    .keys()) {
+    writes.push(tx.del(key));
+  }
+  await Promise.all(writes);
+}
+
+// Supports updates up to length 10^14
+const CHUNK_LENGTH = 10_000;
+export function yjsProviderServerKey(name: string, chunkIndex: number): string {
+  return `yjs/provider/server/${name}/${chunkIndex
+    .toString(10)
+    .padStart(10, '0')}`;
+}
+
+export async function getClientUpdate(
+  name: string,
+  tx: ReadTransaction,
+): Promise<string | undefined> {
+  const v = await tx.get(yjsProviderClientUpdateKey(name));
+  return typeof v === 'string' ? v : undefined;
+}
+
+export async function getServerUpdate(
+  name: string,
+  tx: ReadTransaction,
+): Promise<string | undefined> {
+  const chunks = await tx
+    .scan({
+      prefix: yjsProviderServerUpdatePrefix(name),
+    })
+    .values()
+    .toArray();
+  return chunks.length === 0 ? undefined : chunks.join('');
 }
 
 export function yjsAwarenessKey(

--- a/packages/reflect-yjs/src/provider.test.ts
+++ b/packages/reflect-yjs/src/provider.test.ts
@@ -53,18 +53,15 @@ suite('Provider', () => {
     test('subscribes at construction time', () => {
       const reflect = fakeReflect();
       new Provider(reflect, 'test', new Doc());
-      expect(reflect.subscribe).toHaveBeenCalledTimes(2);
+      expect(reflect.subscribe).toHaveBeenCalledTimes(1);
     });
   });
 
   test('destroy unsubscribes', () => {
     const reflect = new FakeReflect();
     reflect.subscribe.mockClear();
-    const unsubscribe1 = vi.fn();
-    const unsubscribe2 = vi.fn();
-    reflect.subscribe
-      .mockImplementationOnce(() => unsubscribe1)
-      .mockImplementationOnce(() => unsubscribe2);
+    const unsubscribe = vi.fn();
+    reflect.subscribe.mockImplementationOnce(() => unsubscribe);
 
     const p = new Provider(
       reflect as unknown as Reflect<Mutators>,
@@ -73,7 +70,6 @@ suite('Provider', () => {
     );
 
     p.destroy();
-    expect(unsubscribe1).toHaveBeenCalledTimes(1);
-    expect(unsubscribe2).toHaveBeenCalledTimes(1);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Chunks the server update state into 10_000 character chunks.

This works around the 128 KB value size limit for Cloudflare durable storage.

Prior to this change 128 KB was the maximum document size.

Tested with 1, 5 and 10 MB documents.

With this chunking, many edits (adding new lines, editing in the middle of the document, etc), result in all chunks being poked from the server to the clients. So large documents are inefficient but functioning.

We should try to replace this basic chunking approach with a [content-defined chunking approach](https://joshleeb.com/posts/content-defined-chunking.html).