### PR TITLE
perf: Don't send mutations for updates originating from this provider.

### DIFF
--- a/packages/reflect-yjs/src/provider.ts
+++ b/packages/reflect-yjs/src/provider.ts
@@ -85,7 +85,7 @@ export class Provider {
               this.#serverUpdateMeta.length,
             );
             this.#vector = Y.encodeStateVectorFromUpdateV2(this.#serverUpdate);
-            Y.applyUpdateV2(ydoc, this.#serverUpdate);
+            Y.applyUpdateV2(ydoc, this.#serverUpdate, this);
           }
         }
         if (isInitial) {
@@ -94,7 +94,7 @@ export class Provider {
           // All other client updates will have originated from this ydoc
           // and thus not need to be applied.
           if (this.#clientUpdate) {
-            Y.applyUpdateV2(ydoc, this.#clientUpdate);
+            Y.applyUpdateV2(ydoc, this.#clientUpdate, this);
           }
         }
       },
@@ -112,7 +112,10 @@ export class Provider {
     return this.#awareness;
   }
 
-  #handleUpdate = async () => {
+  #handleUpdate = async (_update: unknown, origin: unknown) => {
+    if (origin === this) {
+      return;
+    }
     const diffUpdate = this.#vector
       ? Y.encodeStateAsUpdateV2(this.#ydoc, this.#vector)
       : Y.encodeStateAsUpdateV2(this.#ydoc);


### PR DESCRIPTION
If we don't do this then when a provider receives an update from the server it does not yet have and applies it to the document it resends this update in a mutation to the server which then pokes it out to all other clients.  The loop stops there as the clients all already have the update and so don't emit it again.  Echoing the update back and sending no-op pokes is inefficient, so don't do it.

See https://github.com/yjs/yjs/issues/321#issuecomment-890534515