### PR TITLE
perf: change mutation updates to not be based on server vector

### DIFF
--- a/examples/tiptap/src/components/TextEditor.tsx
+++ b/examples/tiptap/src/components/TextEditor.tsx
@@ -93,7 +93,7 @@ export function Editor({ roomID }: { roomID: string }) {
   useEffect(() => {
     console.log("creating new reflect instance");
 
-    const userID = nanoid();
+    const userID = "anon";
 
     const reflect = new Reflect({
       server,
@@ -101,6 +101,7 @@ export function Editor({ roomID }: { roomID: string }) {
       roomID,
       auth: userID,
       mutators: yjsMutators,
+      kvStore: "idb",
     });
 
     const yDoc = new Y.Doc();

--- a/examples/tiptap/src/components/TextEditor.tsx
+++ b/examples/tiptap/src/components/TextEditor.tsx
@@ -93,7 +93,7 @@ export function Editor({ roomID }: { roomID: string }) {
   useEffect(() => {
     console.log("creating new reflect instance");
 
-    const userID = "anon";
+    const userID = nanoid();
 
     const reflect = new Reflect({
       server,
@@ -101,7 +101,6 @@ export function Editor({ roomID }: { roomID: string }) {
       roomID,
       auth: userID,
       mutators: yjsMutators,
-      kvStore: "idb",
     });
 
     const yDoc = new Y.Doc();

--- a/packages/reflect-yjs/src/mutators.ts
+++ b/packages/reflect-yjs/src/mutators.ts
@@ -187,9 +187,9 @@ export function yjsAwarenessKey(
   reflectClientID: ClientID,
   yjsClientID: number,
 ): string {
-  // -c/${reflectClientID} is a client key space and these are ephemeral. They
+  // -p/${reflectClientID} is a client key space and these are ephemeral. They
   // get deleted when Reflect knows that the client can never come back.
-  return `-/c/${reflectClientID}/yjs/awareness/${name}/${yjsClientID}`;
+  return `-/p/${reflectClientID}/yjs/awareness/${name}/${yjsClientID}`;
 }
 
 export function parseKeyIntoClientIDs(

--- a/packages/reflect-yjs/src/mutators.ts
+++ b/packages/reflect-yjs/src/mutators.ts
@@ -187,7 +187,7 @@ export function yjsAwarenessKey(
   reflectClientID: ClientID,
   yjsClientID: number,
 ): string {
-  // -p/${reflectClientID} is a client key space and these are ephemeral. They
+  // -p/${reflectClientID} is a presence key space and these are ephemeral. They
   // get deleted when Reflect knows that the client can never come back.
   return `-/p/${reflectClientID}/yjs/awareness/${name}/${yjsClientID}`;
 }

--- a/packages/reflect-yjs/src/mutators.ts
+++ b/packages/reflect-yjs/src/mutators.ts
@@ -187,7 +187,7 @@ export function yjsAwarenessKey(
   reflectClientID: ClientID,
   yjsClientID: number,
 ): string {
-  // -p/${reflectClientID} is a presence key space and these are ephemeral. They
+  // -/p/${reflectClientID} is a presence key space and these are ephemeral. They
   // get deleted when Reflect knows that the client can never come back.
   return `-/p/${reflectClientID}/yjs/awareness/${name}/${yjsClientID}`;
 }

--- a/packages/reflect-yjs/src/mutators.ts
+++ b/packages/reflect-yjs/src/mutators.ts
@@ -8,7 +8,6 @@ import type {
 import * as base64 from 'base64-js';
 import * as Y from 'yjs';
 import {chunk, unchunk} from './chunk.js';
-import {uuidv4} from 'lib0/random.js';
 
 export const mutators = {
   yjsSetLocalStateField,

--- a/packages/reflect-yjs/src/mutators.ts
+++ b/packages/reflect-yjs/src/mutators.ts
@@ -25,7 +25,7 @@ export type UpdateYJSArgs = {
 export function updateYJS(args?: UpdateYJSArgs | undefined) {
   return async function (
     tx: WriteTransaction,
-    {name, update}: {name: string; update: string},
+    {name, id, update}: {name: string; id: string; update: string},
   ) {
     const {validator} = args ?? {};
     if (tx.location === 'server') {
@@ -52,7 +52,7 @@ export function updateYJS(args?: UpdateYJSArgs | undefined) {
       if (validator) {
         throw new Error('validator only supported on server');
       }
-      await setClientUpdate(name, update, tx);
+      await setClientUpdate(name, id, update, tx);
     }
   };
 }
@@ -88,8 +88,13 @@ export function yjsProviderServerChunkKey(
   return `${yjsProviderServerUpdateChunkKeyPrefix(name)}${chunkHash}`;
 }
 
-function setClientUpdate(name: string, update: string, tx: WriteTransaction) {
-  return tx.set(yjsProviderClientUpdateKey(name, uuidv4()), update);
+function setClientUpdate(
+  name: string,
+  id: string,
+  update: string,
+  tx: WriteTransaction,
+) {
+  return tx.set(yjsProviderClientUpdateKey(name, id), update);
 }
 
 const AVG_CHUNK_SIZE_B = 1024;

--- a/packages/reflect-yjs/src/provider.ts
+++ b/packages/reflect-yjs/src/provider.ts
@@ -10,6 +10,7 @@ import {
   yjsProviderServerUpdateMetaKey,
 } from './mutators.js';
 import {unchunk} from './chunk.js';
+import {uuidv4} from 'lib0/random.js';
 
 export class Provider {
   readonly #reflect: Reflect<Mutators>;
@@ -101,6 +102,7 @@ export class Provider {
     }
     await this.#reflect.mutate.updateYJS({
       name: this.name,
+      id: uuidv4(),
       update: base64.fromByteArray(updateV2),
     });
   };


### PR DESCRIPTION
The updates in mutations are now just the update message fired by the ydoc.  It is not necessary for these to be based on a vector of a previous server state.  As long as all update messages are propagated to all clients, all clients will eventually converge to the same state.  This is ensured by the reflect mutation/push system ensuring all updates flow from a source ydoc to the server, where they are merged into the server update which is then poked to all clients.

Since the updates in mutations are no longer cumulative each client update is written at its own key (using a uuid).   These are not written by the server handling of the mutation, and thus are effectively deleted once they are merged into the server update.

Tested loading of the doc from offline using `kvStore: 'idb'` and also offline persist/refresh.